### PR TITLE
Centralize RabbitMQ configuration

### DIFF
--- a/create-users/src/main.ts
+++ b/create-users/src/main.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
-import { Transport } from '@nestjs/microservices';
+import { getRmqConfig } from '../../libs/rabbitmq/rmq.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -16,17 +16,8 @@ async function bootstrap() {
     }),
   );
 
-  // 🚀 Configuramos el microservicio RabbitMQ (sin quitar nada de lo anterior)
-  app.connectMicroservice({
-    transport: Transport.RMQ,
-    options: {
-      urls: ['amqp://localhost:5672'],
-      queue: 'user_created',
-      queueOptions: {
-        durable: false,
-      },
-    },
-  });
+  // Configure RabbitMQ microservice using centralized config
+  app.connectMicroservice(getRmqConfig('user_created'));
 
   // 🚀 Iniciamos el microservicio RabbitMQ
   await app.startAllMicroservices();

--- a/libs/rabbitmq/rmq.config.ts
+++ b/libs/rabbitmq/rmq.config.ts
@@ -1,0 +1,14 @@
+import { RmqOptions, Transport } from '@nestjs/microservices';
+
+export function getRmqConfig(queue: string): RmqOptions {
+  return {
+    transport: Transport.RMQ,
+    options: {
+      urls: [process.env.RABBITMQ_URI || 'amqp://localhost:5672'],
+      queue,
+      queueOptions: {
+        durable: false,
+      },
+    },
+  };
+}

--- a/register-users/src/auth/auth.service.ts
+++ b/register-users/src/auth/auth.service.ts
@@ -8,8 +8,8 @@ import { RegisterDto } from './dto/register.dto';
 import {
   ClientProxy,
   ClientProxyFactory,
-  Transport,
 } from '@nestjs/microservices';
+import { getRmqConfig } from '../../../libs/rabbitmq/rmq.config';
 import * as bcryptjs from 'bcryptjs';
 import { firstValueFrom } from 'rxjs';
 
@@ -18,16 +18,7 @@ export class AuthService implements OnModuleInit {
   private client: ClientProxy;
 
   async onModuleInit() {
-    this.client = ClientProxyFactory.create({
-      transport: Transport.RMQ,
-      options: {
-        urls: ['amqp://localhost:5672'],
-        queue: 'user_created',
-        queueOptions: {
-          durable: false,
-        },
-      },
-    });
+    this.client = ClientProxyFactory.create(getRmqConfig('user_created'));
 
     await this.client.connect();
   }


### PR DESCRIPTION
## Summary
- add a shared `getRmqConfig` helper
- use the helper in `create-users` and `register-users`

## Testing
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_684c4a4563f88330b322bf14addb4bbd